### PR TITLE
Added a random artist button with logic

### DIFF
--- a/src/components/SearchBox.tsx
+++ b/src/components/SearchBox.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, ChangeEvent, KeyboardEvent } from 'react';
+import { useState, useEffect, ChangeEvent, KeyboardEvent } from 'react';
 import axios from 'axios';
 import {
   Stack,
@@ -14,6 +14,12 @@ import { useMusicolorStore } from '../hooks/store';
 
 interface SearchBoxProps {
   setSearchResults: React.Dispatch<React.SetStateAction<never[]>>;
+}
+
+interface Song {
+  'im:artist': {
+    label: string;
+  };
 }
 
 const SearchBox = ({ setSearchResults }: SearchBoxProps) => {
@@ -62,7 +68,7 @@ const SearchBox = ({ setSearchResults }: SearchBoxProps) => {
     try {
       const { data } = await axios.get(RANDOM_ARTIST_API_URL);
 
-      const songs = data.feed.entry;
+      const songs: Song[] = data.feed.entry;
       if (!songs || songs.length === 0) {
         console.log('No songs found.');
         return;
@@ -183,7 +189,7 @@ const SearchBox = ({ setSearchResults }: SearchBoxProps) => {
           size='large'
           aria-label='random-artist'
         >
-          I am one lucky onion
+          Random
         </Button>
       </Stack>
     </Stack>

--- a/src/config/API_URL.ts
+++ b/src/config/API_URL.ts
@@ -1,3 +1,4 @@
 export const API_URL = 'https://itunes.apple.com/search';
 export const DETAILS_URL = 'https://itunes.apple.com/lookup';
 export const NUMBER_OF_RESULTS = '50';
+export const RANDOM_ARTIST_API_URL = 'https://itunes.apple.com/us/rss/topsongs/limit=10/json';


### PR DESCRIPTION
## Short description:
A new button has been introduced. The way it works is that when you click on the button it does a URL req to the itunes rss feed and returns the top 10 artists being streamed right now. It extracts the name of each artist and randomly selects one artist and uses that value with the `getSearchResult` function to post results.

**Suggestion**: Would like to add functionality that when you click on the new button that the CLEAR button is activated and if you use the CLEAR button it clears the results like when you use the SEARCH button.

**NOTE**: everything in this PR is subjected to change or reverting it to it's original state.

## What did I change:
* added a new button
* added logic for said button
* added a new API URL

## Screenshots
![image](https://github.com/e1401/musicolor/assets/91826152/dae4a70c-6200-40c6-bf0a-aa0621fcb884)
![image](https://github.com/e1401/musicolor/assets/91826152/c17d8e7c-6dce-4166-ad62-74aee50486b7)
